### PR TITLE
Fix 701 Role info should contain description

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 galaxy_info:
+  description: "Set variables from fai-config"
   author: lihas@lihas.de
 allow_duplicates: false


### PR DESCRIPTION
ansible-lint:
701 Role info should contain description
/tmp/ansible-lihas-variables/meta/main.yml:2
{'meta/main.yml': {'galaxy_info': {'author': 'lihas@lihas.de', '__line__': 3, '__file__': '/tmp/ansible-lihas-variables/meta/main.yml'}, 'allow_duplicates': False, '__line__': 2, '__file__': '/tmp/ansible-lihas-variables/meta/main.yml', 'skipped_rules': []}}