### PR TITLE
Role info should contain min ansible version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,4 +3,5 @@ galaxy_info:
   description: "Set variables from fai-config"
   license: GPLv3
   author: lihas@lihas.de
+  min_ansible_version: 2.1
 allow_duplicates: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 galaxy_info:
+  description: "Set variables from fai-config"
   author: lihas@lihas.de
 allow_duplicates: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
   description: "Set variables from fai-config"
+  license: GPLv3
   author: lihas@lihas.de
 allow_duplicates: false


### PR DESCRIPTION
ansible-lint:
701 Role info should contain min_ansible_version
`
/tmp/ansible-lihas-variables/meta/main.yml:2
{'meta/main.yml': {'galaxy_info': {'author': 'lihas@lihas.de', '__line__': 3, '__file__': '/tmp/ansible-lihas-variables/meta/main.yml'}, 'allow_duplicates': False, '__line__': 2, '__file__': '/tmp/ansible-lihas-variables/meta/main.yml', 'skipped_rules': []}}
`